### PR TITLE
Fixes #9 pocketmine killed without gracefully shutdown when docker stopped

### DIFF
--- a/pocketmine-mp/Dockerfile
+++ b/pocketmine-mp/Dockerfile
@@ -59,4 +59,4 @@ EXPOSE 19132/udp
 
 VOLUME ["/data", "/plugins"]
 
-CMD start-pocketmine
+ENTRYPOINT ["start-pocketmine"]

--- a/pocketmine-mp/Dockerfile
+++ b/pocketmine-mp/Dockerfile
@@ -59,4 +59,4 @@ EXPOSE 19132/udp
 
 VOLUME ["/data", "/plugins"]
 
-CMD start-pocketmine
+CMD ["start-pocketmine"]

--- a/pocketmine-mp/Dockerfile
+++ b/pocketmine-mp/Dockerfile
@@ -59,4 +59,4 @@ EXPOSE 19132/udp
 
 VOLUME ["/data", "/plugins"]
 
-ENTRYPOINT ["start-pocketmine"]
+CMD start-pocketmine

--- a/pocketmine-mp/start.sh
+++ b/pocketmine-mp/start.sh
@@ -32,4 +32,4 @@ fi
 
 # Run the server
 cd /pocketmine
-php PocketMine-MP.phar --no-wizard --enable-ansi --data=/data --plugins=/plugins
+exec php PocketMine-MP.phar --no-wizard --enable-ansi --data=/data --plugins=/plugins


### PR DESCRIPTION
`exec` command will replace start.sh to PocketMine process.

Reference : [https://hynek.me/articles/docker-signals/](https://hynek.me/articles/docker-signals/)

Tested and see result.

## Before
![](https://i.imgur.com/UOvemSP.png)
Stoppin docker. But stopped without unload.

![](https://i.imgur.com/lhUGyVx.png)
PID is mapped to 10. `SIGTERM` is not reach to PocketMine process.

## After
![](https://i.imgur.com/7xAnaFt.png)
Stopping docker and unloaded successfully.

![](https://i.imgur.com/Yqy006Q.png)
`docker stop` send  `SIGTERM` to process PID=1, so now PocketMine can handle `SIGTERM` directly.