### PR TITLE
Fix typo of Dockerile to Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Unlike early pmmp/pocketmine-mp images, this default user is no longer a sudoer,
 so plugins cannot acquire root access under normal circumstances.
 
 ## Building this image
-The Dockerile requires a build-arg `PMMP_TAG` indicating the tree on pmmp/PocketMine-MP to checkout for building.
+The Dockerfile requires a build-arg `PMMP_TAG` indicating the tree on pmmp/PocketMine-MP to checkout for building.
 Currently, this image does not support building from local PocketMine-MP source directories
 and always uses a tree from pmmp/PocketMine-MP on GitHub.
 However, this can be easily changed by simply changing the `git clone` command.


### PR DESCRIPTION
Fixes a typo in the last paragraph of the README